### PR TITLE
fix scaffolding.lua hiding sec and sec* snippets

### DIFF
--- a/lua/luasnip-latex-snippets/luasnippets/tex/utils/scaffolding.lua
+++ b/lua/luasnip-latex-snippets/luasnippets/tex/utils/scaffolding.lua
@@ -94,7 +94,9 @@ M.symbol_snippet = function(context, command, opts)
     if j == 2 then -- command always starts with backslash
         context.trigEngine = "ecma"
         context.trig = "(?<!\\\\)" .. "(" .. context.trig .. ")"
-        context.hidden = true
+        if context.snippetType == "autosnippet" then
+            context.hidden = true
+        end
     end
 	return autosnippet(context, t(command), opts)
 end


### PR DESCRIPTION
fixes issue #9 by not hiding snippets when they start with the same letters as the command